### PR TITLE
Add test coverage for helpers

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+java_script:
+  config_file: tests/.jshintrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 ---
 language: node_js
-node_js:
-  - "0.12"
 
 sudo: false
 
@@ -9,29 +7,31 @@ cache:
   directories:
     - node_modules
 
-notifications:
-  email: false
-
-env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
-
-before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
-
 install:
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
+
   - npm install -g bower
   - npm install
   - bower install
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMBER_VERSION='ember-release'
+    - env: EMBER_VERSION='ember-beta'
+    - env: EMBER_VERSION='ember-canary'
+  include:
+    - env: "EMBER_VERSION='default'"
+    - env: "EMBER_VERSION='ember-release'"
+    - env: "EMBER_VERSION='ember-beta'"
+    - env: "EMBER_VERSION='ember-canary'"
+
+notifications:
+  email: false
+
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  # run our tests against the Ember version and browser of our choice
+  - ember try ${EMBER_VERSION} test --port=8080 --skip-cleanup

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Then, import the helpers you need:
 import { clickOn, findRole } from 'ember-tb-test-helpers';
 
 test('it works', assert => {
-  assert.notInclude('foo', 'bar', 'foo is not bar');
+  clickOn('Foo!');
+
+  andThen(() => {
+    assert.notInclude(findRole('foo').text(), 'bar', 'foo is not bar');
+  });
 });
 ```
 

--- a/tests/acceptance/app-uses-helpers-test.js
+++ b/tests/acceptance/app-uses-helpers-test.js
@@ -1,0 +1,64 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../../tests/helpers/start-app';
+import {
+  clickOn,
+  clickRole,
+  fillInField,
+  findRole,
+} from 'ember-tb-test-helpers';
+
+module('Acceptance | App uses helpers', {
+  beforeEach() {
+    this.application = startApp();
+  },
+
+  afterEach() {
+    Ember.run(this.application, 'destroy');
+  }
+});
+
+test('finders', assert => {
+  visit('/');
+
+  clickOn('Checkbox!');
+  clickOn('Submit!');
+  clickRole('outer', 'middle', 'inner', 'checkbox');
+  fillInField('the-input', 'fillInField');
+
+  andThen(() => {
+    assert.textEqual(
+      findRole('outer', 'middle', 'inner'),
+      'findRole',
+      'findRole finds by `[data-role]`'
+    );
+    assert.textEqual(
+      findWithAssert('[name="the-input"]').val(),
+      'fillInField',
+      'fillInField fills inputs by `[name]`'
+    );
+    assert.ok(
+      findWithAssert('#labelled-checkbox').prop('checked'),
+      'clickOn finds by `:contains`'
+    );
+    assert.ok(
+      findWithAssert('#submitted'),
+      'clickOn finds by `[value]` works'
+    );
+    assert.ok(
+      findWithAssert('#checkbox-role').prop('checked'),
+      'clickRole finds by `[data-role]`'
+    );
+  });
+});
+
+test('include and notInclude matchers', assert => {
+  visit('/');
+
+  andThen(() => {
+    const theText = findWithAssert('#the-text');
+
+    assert.include(theText, 'needle', 'the text includes the search term');
+    assert.notInclude(theText, 'haystack', 'the text excludes a bad term');
+  });
+});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  submitted: false,
+
+  actions: {
+    submit() {
+      this.set('submitted', true);
+    }
+  },
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,24 @@
-<h2 id="title">Welcome to Ember</h2>
+<div data-role="outer">
+  <div data-role="middle">
+    <div data-role="inner">
+      findRole
 
-{{outlet}}
+      <input id="checkbox-role" type="checkbox" data-role="checkbox">
+    </div>
+  </div>
+</div>
+
+<input name="the-input">
+
+<label for="labelled-checkbox">Checkbox!</label>
+<input id="labelled-checkbox" type="checkbox">
+
+{{#if submitted}}
+  <span id="submitted"></span>
+{{/if}}
+
+<input {{action "submit"}} type="submit" value="Submit!">
+
+<div id="the-text">
+  This is filler text. Includes the word "needle".
+</div>


### PR DESCRIPTION
Helpers weren't previously covered by tests.

Removes `clickOn` method. For clicking on text, consumers should use
[ember-formulaic](https://github.com/thoughtbot/ember-formulaic).
