### PR TITLE
Introduce `within` test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Introduce `within` helper, for scoping helpers to a selector
+
 0.0.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ First, install the addon:
 Then, import the helpers you need:
 
 ```js
+// tests/helpers/start-app.js
+
+import './ember-tb-test-helpers/test-helpers';
+// ...
+```
+
+```js
+// tests/acceptance/your-test.js
 import { clickOn, findRole } from 'ember-tb-test-helpers';
 
 test('it works', assert => {
@@ -35,6 +43,10 @@ import 'ember-tb-test-helpers/extend-qunit';
 * `findRole(role)` - Finds (with assert) an element with matching `[data-role]`
 * `fillInField(name, value)` - Fills in a field with a `[name]` with the given
   value
+* [`within(scope, block)`][within] - Scopes subsequent calls to test helpers by
+  the provided selector.
+
+[within]: tests/acceptance/app-uses-helpers-test.js
 
 ## QUnit Matchers
 

--- a/addon/scope.js
+++ b/addon/scope.js
@@ -1,0 +1,44 @@
+import Ember from 'ember';
+
+const BLACKLISTED_HELPERS = [
+  'visit',
+  'currentPath',
+  'currentRouteName',
+  'currentURL',
+];
+
+function defineTestHelpers(context) {
+  Object.keys(context.app.testHelpers).forEach(name => {
+    const helper = context.app.testHelpers[name];
+    context[name] = function(selector, ...args) {
+      return helper(`${context.selector} ${selector}`, ...args);
+    }.bind(context);
+  });
+}
+
+function blacklistTestHelpers(context) {
+  BLACKLISTED_HELPERS.forEach(name => {
+    context[name] = function() {
+      throw new Ember.Error(
+        `Unexpected call to 'scope.${name}'. Scopes created by 'within' only
+        support Ember test helpers that accept a selector as the
+        first argument.`
+      );
+    }.bind(context);
+  });
+}
+
+class Scope {
+  constructor(app, selector) {
+    this.app = app;
+    this.selector = selector;
+    defineTestHelpers(this);
+    blacklistTestHelpers(this);
+  }
+
+  within(selector, block, ...args) {
+    return block(new Scope(this.app, `${this.selector} ${selector}`, ...args));
+  }
+}
+
+export default Scope;

--- a/addon/within.js
+++ b/addon/within.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import Scope from './scope';
+
+Ember.Test.registerHelper('within', function(app, selector, block) {
+  const {
+    wait
+  } = app.testHelpers;
+
+  block(new Scope(app, selector));
+
+  return wait();
+});

--- a/test-support/helpers/ember-tb-test-helpers/test-helpers.js
+++ b/test-support/helpers/ember-tb-test-helpers/test-helpers.js
@@ -1,0 +1,1 @@
+import 'ember-tb-test-helpers/within';

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,5 +1,6 @@
 {
   "predef": [
+    "within",
     "document",
     "window",
     "location",

--- a/tests/acceptance/app-uses-helpers-test.js
+++ b/tests/acceptance/app-uses-helpers-test.js
@@ -62,3 +62,79 @@ test('include and notInclude matchers', assert => {
     assert.notInclude(theText, 'haystack', 'the text excludes a bad term');
   });
 });
+
+test('within', assert => {
+  visit('/');
+
+  within('form .included', scope => {
+    scope.click('[type="checkbox"]');
+    scope.fillIn('[type="text"]', 'scoped');
+
+    andThen(() => {
+      const submit = scope.find('[type="submit"]');
+      const button = scope.findWithAssert('button');
+
+      assert.ok(
+        findWithAssert('#included-checkbox').prop('checked'),
+        'scoped `click` works'
+      );
+      assert.textEqual(
+        findWithAssert('#included-text').val(),
+        'scoped',
+        'scoped `fillIn` works'
+      );
+
+      assert.ok(
+        !findWithAssert('#excluded-checkbox').prop('checked'),
+        'scoped `click` works'
+      );
+      assert.textEqual(
+        findWithAssert('#excluded-text').val(),
+        '',
+        'scoped `fillIn` works'
+      );
+
+      assert.equal(submit.length, 1, 'scoped `find` works');
+      assert.textEqual(submit.val(), 'included', 'scoped `find` works');
+      assert.equal(button.length, 1, 'scoped `findWithAssert` works');
+      assert.textEqual(button, 'included', 'scoped `findWithAssert` works');
+    });
+  });
+});
+
+test('within raises warnings', assert => {
+  within('', scope => {
+    assert.throws(
+      () => scope.visit('ignore'),
+      Ember.Error,
+      'throws error for `visit`'
+    );
+    assert.throws(
+      () => scope.currentPath(),
+      Ember.Error,
+      'throws error for `currentPath`'
+    );
+    assert.throws(
+      () => scope.currentRouteName(),
+      Ember.Error,
+      'throws error for `currentRouteName`'
+    );
+    assert.throws(
+      () => scope.currentURL(),
+      Ember.Error,
+      'throws error for `currentURL`'
+    );
+  });
+});
+
+test('scoped within', assert => {
+  visit('/');
+
+  within('form .included', scope => {
+    scope.within('.inner-included', innerScope => {
+      andThen(() => {
+        assert.ok(innerScope.findWithAssert('span'), 'nested within works');
+      });
+    });
+  });
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,3 +22,23 @@
 <div id="the-text">
   This is filler text. Includes the word "needle".
 </div>
+
+<form>
+  <div class="included">
+    <input id="included-checkbox" type="checkbox">
+    <input id="included-text" type="text">
+    <input type="submit" value="included">
+    <button>included</button>
+
+    <div class="inner-included">
+      <span></span>
+    </div>
+  </div>
+
+  <div class="excluded">
+    <input id="excluded-checkbox" type="checkbox">
+    <input id="excluded-text" type="text">
+    <input type="submit" value="excluded">
+    <button>excluded</button>
+  </div>
+</form>

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
+import './ember-tb-test-helpers/test-helpers';
 
 export default function startApp(attrs) {
   var application;


### PR DESCRIPTION
`within` can be used both asynchronously and synchronously.

Scope subsequent helper calls with `within`. For example:

``` js
// tests/helpers/start-app.js

import './ember-tb-test-helpers/test-helpers';

// ...
// tests/acceptance/the-test.js

test('a feature', assert => {
  visit('/');

  within('form.login .input-group', scope => {
    scope.click('[type="checkbox"]');

    andThen(() => {
      assert.equal(
       scope.findWithAssert('span').text(),
       'Checkbox checked!'
      );
    });
  });
});
```

We're reflectively defining the Scope's helper methods based on existing
test helpers, registered via
`Ember.Test.{registerHelper,registerAsyncHelper}`.

We'll also throw an error for Ember test helpers that **don't** accept a
selector as their first argument.
