### PR TITLE
Introduce `assert.hasClass` matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Introduce `assert.hasClass` matcher
+
 0.0.2
 -----
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ import 'ember-tb-test-helpers/extend-qunit';
   included in the `haystack` string
 * `assert.textEqual(expected, actual)` - Asserts that the `expected` string or
   node's text equals the `actual` string
+* `assert.hasClass(expected, actual)` - Asserts that the `expected` node or
+  selector has the `actual` class
 
 ## Installation
 

--- a/addon/extend-qunit.js
+++ b/addon/extend-qunit.js
@@ -1,4 +1,7 @@
+import Ember from 'ember';
 import QUnit from 'qunit';
+
+const { assert } = QUnit;
 
 function normalizeString(actual) {
   if (!actual) {
@@ -12,7 +15,7 @@ function normalizeString(actual) {
   }
 }
 
-QUnit.assert.textEqual = function(actual, expected, message) {
+assert.textEqual = function(actual, expected, message) {
   const actualString = normalizeString(actual);
 
   const trimActual = actualString
@@ -23,7 +26,7 @@ QUnit.assert.textEqual = function(actual, expected, message) {
   this.equal(trimActual, expected, message);
 };
 
-QUnit.assert.include = function(actual, expected, message) {
+assert.include = function(actual, expected, message) {
   const actualString = normalizeString(actual);
 
   if (!message) {
@@ -33,7 +36,7 @@ QUnit.assert.include = function(actual, expected, message) {
   this.ok(actualString.indexOf(expected) !== -1, message);
 };
 
-QUnit.assert.notInclude = function(actual, expected, message) {
+assert.notInclude = function(actual, expected, message) {
   const actualString = normalizeString(actual);
 
   if (!message) {
@@ -41,4 +44,15 @@ QUnit.assert.notInclude = function(actual, expected, message) {
   }
 
   this.ok(actualString.indexOf(expected) === -1, message);
+};
+
+assert.hasClass = function(selectorOrNode, expected, message) {
+  const node = Ember.$(selectorOrNode);
+  const classes = node.prop('class');
+
+  if (!message) {
+    message = `expected node to include "${expected}" class in "${classes}"`;
+  }
+
+  this.ok(node.hasClass(expected.toString()), message);
 };

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "qunit": "~1.17.1",
+    "es5-shim": "^4.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ember-cli-app-version": "0.4.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-es5-shim": "0.1.1",
     "ember-cli-htmlbars": "0.7.9",
     "ember-cli-htmlbars-inline-precompile": "^0.1.1",
     "ember-cli-ic-ajax": "0.2.1",
@@ -32,9 +33,9 @@
     "ember-cli-sri": "^1.0.1",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.13.7",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6"
   },
   "keywords": [

--- a/tests/acceptance/app-uses-helpers-test.js
+++ b/tests/acceptance/app-uses-helpers-test.js
@@ -27,6 +27,8 @@ test('finders', assert => {
   fillInField('the-input', 'fillInField');
 
   andThen(() => {
+    assert.hasClass('.included', 'included');
+    assert.hasClass(findWithAssert('.included'), 'included');
     assert.textEqual(
       findRole('outer', 'middle', 'inner'),
       'findRole',


### PR DESCRIPTION
Asserts that either a node, or a node found with a selector has the
given class:

``` js
assert.hasClass(node, 'the-class');
assert.hasClass(findWithAssert('.the-class'), 'the-class');
```
- Adds `ember-cli-es5-shim` to the project for local testers forced to
  stick with `phantomjs@1.9.x`. This won't be included in consumer apps
