### PR TITLE
Rename project to `ralphs-little-helpers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
-# ember-tb-test-helpers
+# ralphs-little-helpers
 
 This README outlines the details of collaborating on this Ember addon.
+
 ## Usage
 
 First, install the addon:
 
-    $ ember install ember-tb-test-helpers
+    $ ember install ralphs-little-helpers
 
 Then, import the helpers you need:
 
 ```js
 // tests/helpers/start-app.js
 
-import './ember-tb-test-helpers/test-helpers';
+import './ralphs-little-helpers/test-helpers';
 // ...
 ```
 
 ```js
 // tests/acceptance/your-test.js
-import { clickOn, findRole } from 'ember-tb-test-helpers';
+import { clickOn, findRole } from 'ralphs-little-helpers';
 
 test('it works', assert => {
   clickOn('Foo!');
@@ -33,7 +34,7 @@ To use the matchers, import them in your test helper:
 
 ```js
 // tests/test-helper.js
-import 'ember-tb-test-helpers/extend-qunit';
+import 'ralphs-little-helpers/extend-qunit';
 ```
 
 ## Helpers
@@ -87,11 +88,11 @@ See the [CONTRIBUTING] document.
 Thank you, [contributors]!
 
   [CONTRIBUTING]: CONTRIBUTING.md
-  [contributors]: https://github.com/thoughtbot/ember-tb-test-helpers/graphs/contributors
+  [contributors]: https://github.com/thoughtbot/ralphs-little-helpers/graphs/contributors
 
 ## License
 
-ember-tb-test-helpers is Copyright (c) 2015 thoughtbot, inc.
+ralphs-little-helpers is Copyright (c) 2015 thoughtbot, inc.
 It is free software, and may be redistributed
 under the terms specified in the [LICENSE] file.
 
@@ -99,13 +100,13 @@ under the terms specified in the [LICENSE] file.
 
 ## About
 
-ember-tb-test-helpers is maintained by [Sean Doyle][seanpdoyle].
+ralphs-little-helpers is maintained by [Sean Doyle][seanpdoyle].
 
 ![thoughtbot](https://thoughtbot.com/logo.png)
 
   [seanpdoyle]: https://github.com/seanpdoyle
 
-ember-tb-test-helpers is maintained and funded by thoughtbot, inc.
+ralphs-little-helpers is maintained and funded by thoughtbot, inc.
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.
 
 We love open source software!

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,8 @@
-import findRole from 'ember-tb-test-helpers/find-role';
-import clickOn from 'ember-tb-test-helpers/click-on';
-import clickRole from 'ember-tb-test-helpers/click-role';
-import fillInField from 'ember-tb-test-helpers/fill-in-field';
-import 'ember-tb-test-helpers/extend-qunit';
+import findRole from 'ralphs-little-helpers/find-role';
+import clickOn from 'ralphs-little-helpers/click-on';
+import clickRole from 'ralphs-little-helpers/click-role';
+import fillInField from 'ralphs-little-helpers/fill-in-field';
+import 'ralphs-little-helpers/extend-qunit';
 
 export {
   clickOn,

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-tb-test-helpers",
+  "name": "ralphs-little-helpers",
   "dependencies": {
     "ember": "1.13.5",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-tb-test-helpers'
+  name: 'ralphs-little-helpers'
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-tb-test-helpers",
+  "name": "ralphs-little-helpers",
   "version": "0.0.3",
   "description": "thoughtbot's Ember Test Helpers",
   "directories": {
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "https://github.com/thoughtbot/ember-tb-test-helpers",
+  "repository": "https://github.com/thoughtbot/ralphs-little-helpers",
   "engines": {
     "node": ">= 0.10.0"
   },
@@ -39,7 +39,10 @@
     "ember-try": "0.0.6"
   },
   "keywords": [
-    "ember-addon"
+    "ember-addon",
+    "test helpers",
+    "qunit matchers",
+    "thoughtbot"
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0"

--- a/test-support/helpers/ember-tb-test-helpers/test-helpers.js
+++ b/test-support/helpers/ember-tb-test-helpers/test-helpers.js
@@ -1,1 +1,0 @@
-import 'ember-tb-test-helpers/within';

--- a/test-support/helpers/ralphs-little-helpers/test-helpers.js
+++ b/test-support/helpers/ralphs-little-helpers/test-helpers.js
@@ -1,0 +1,1 @@
+import 'ralphs-little-helpers/within';

--- a/tests/acceptance/app-uses-helpers-test.js
+++ b/tests/acceptance/app-uses-helpers-test.js
@@ -6,7 +6,7 @@ import {
   clickRole,
   fillInField,
   findRole,
-} from 'ember-tb-test-helpers';
+} from 'ralphs-little-helpers';
 
 module('Acceptance | App uses helpers', {
   beforeEach() {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
-import './ember-tb-test-helpers/test-helpers';
+import './ralphs-little-helpers/test-helpers';
 
 export default function startApp(attrs) {
   var application;


### PR DESCRIPTION
`ember-tb-test-helpers` is an awful name.

Some conversations held internal to thoughtbot yielded
`ralphs-little-helpers`, which was well received.

Our only concern is that this `ember-addon` isn't prefixed with
`ember-`.

We're not very concerned with that fact, but it's on our radar. If we
run into issues in the future, we'll pick a better name.

Amazingly, `ember-tb-test-helpers` and `ralphs-little-helpers` contain
the same number of characters :tada:.
