### PR TITLE
Introduce `check` and `uncheck` async helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ master
 ------
 
 * Fix `assert.include` and `assert.notInclude` default failure message.
+* Introduce `check` and `uncheck` global async helpers.
+  Introduce `assert.checked` and `assert.unchecked`. [#9]
+
+[#9]: https://github.com/thoughtbot/ralphs-little-helpers/pull/9
 
 0.0.3
 -----

--- a/README.md
+++ b/README.md
@@ -39,11 +39,18 @@ import 'ralphs-little-helpers/extend-qunit';
 
 ## Helpers
 
+**Imported**
+
 * `clickOn(text)` - Clicks on elements containing the text
 * `clickRole(role)` - Clicks on elements with a matching `[data-role]`
 * `findRole(role)` - Finds (with assert) an element with matching `[data-role]`
 * `fillInField(name, value)` - Fills in a field with a `[name]` with the given
   value
+
+**Global**
+
+* `check(selector, context)` - Ensure an `input[type="checkbox"]` is checked
+* `uncheck(selector, context)` - Ensure an `input[type="checkbox"]` is unchecked
 * [`within(scope, block)`][within] - Scopes subsequent calls to test helpers by
   the provided selector.
 
@@ -59,6 +66,10 @@ import 'ralphs-little-helpers/extend-qunit';
   node's text equals the `actual` string
 * `assert.hasClass(expected, actual)` - Asserts that the `expected` node or
   selector has the `actual` class
+* `assert.checked(expected, message)` - Asserts that the `expected` node or
+  selector is `:checked`
+* `assert.unchecked(expected, message)` - Asserts that the `expected` node or
+  selector is not `:checked`
 
 ## Installation
 

--- a/addon/checkbox-helpers.js
+++ b/addon/checkbox-helpers.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+
+const { assert, run } = Ember;
+
+function ensureCheckState(isChecked, app, selector, context) {
+  const {
+    click,
+    findWithAssert
+  } = app.testHelpers;
+  const word = isChecked ? 'check' : 'uncheck';
+
+  const $element = findWithAssert(selector, context);
+  assert(
+    `To ${word} '${selector}', the input must be a checkbox`,
+    $element.prop('type') === 'checkbox'
+  );
+
+  run(() => {
+    if ($element.is(':checked') !== isChecked) {
+      click($element);
+    }
+  });
+}
+
+Ember.Test.registerAsyncHelper('check', function() {
+  ensureCheckState(true, ...arguments);
+});
+
+Ember.Test.registerAsyncHelper('uncheck', function() {
+  ensureCheckState(false, ...arguments);
+});

--- a/addon/extend-qunit.js
+++ b/addon/extend-qunit.js
@@ -56,3 +56,25 @@ assert.hasClass = function(selectorOrNode, expected, message) {
 
   this.ok(node.hasClass(expected.toString()), message);
 };
+
+assert.checked = function(selectorOrNode, message) {
+  const node = Ember.$(selectorOrNode);
+  const checked = node.is(':checked');
+
+  if (!message) {
+    message = `expected node (${selectorOrNode.toString()}) to be checked`;
+  }
+
+  this.ok(checked, message);
+};
+
+assert.unchecked = function(selectorOrNode, message) {
+  const node = Ember.$(selectorOrNode);
+  const unchecked = !node.is(':checked');
+
+  if (!message) {
+    message = `expected node (${selectorOrNode.toString()}) to be unchecked`;
+  }
+
+  this.ok(unchecked, message);
+};

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,8 @@
-import findRole from 'ralphs-little-helpers/find-role';
-import clickOn from 'ralphs-little-helpers/click-on';
-import clickRole from 'ralphs-little-helpers/click-role';
-import fillInField from 'ralphs-little-helpers/fill-in-field';
-import 'ralphs-little-helpers/extend-qunit';
+import findRole from './find-role';
+import clickOn from './click-on';
+import clickRole from './click-role';
+import fillInField from './fill-in-field';
+import './extend-qunit';
 
 export {
   clickOn,

--- a/test-support/helpers/ralphs-little-helpers/test-helpers.js
+++ b/test-support/helpers/ralphs-little-helpers/test-helpers.js
@@ -1,1 +1,2 @@
+import 'ralphs-little-helpers/checkbox-helpers';
 import 'ralphs-little-helpers/within';

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,5 +1,7 @@
 {
   "predef": [
+    "check",
+    "uncheck",
     "within",
     "document",
     "window",

--- a/tests/acceptance/app-uses-helpers-test.js
+++ b/tests/acceptance/app-uses-helpers-test.js
@@ -65,6 +65,31 @@ test('include and notInclude matchers', assert => {
   });
 });
 
+test('checkbox helpers', assert => {
+  visit('/');
+
+  andThen(() => {
+    assert.checked('#checked-checkbox');
+    assert.unchecked('#unchecked-checkbox');
+  });
+
+  check('#checked-checkbox');
+  uncheck('#unchecked-checkbox');
+
+  andThen(() => {
+    assert.checked('#checked-checkbox');
+    assert.unchecked('#unchecked-checkbox');
+  });
+
+  check('#unchecked-checkbox');
+  uncheck('#checked-checkbox');
+
+  andThen(() => {
+    assert.unchecked('#checked-checkbox');
+    assert.checked('#unchecked-checkbox');
+  });
+});
+
 test('within', assert => {
   visit('/');
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -13,6 +13,9 @@
 <label for="labelled-checkbox">Checkbox!</label>
 <input id="labelled-checkbox" type="checkbox">
 
+<input id="unchecked-checkbox" type="checkbox">
+<input id="checked-checkbox" type="checkbox" checked>
+
 {{#if submitted}}
   <span id="submitted"></span>
 {{/if}}


### PR DESCRIPTION
Promotes `check` and `uncheck` test helpers from [emberjs/ember.js](https://github.com/emberjs/ember.js/pull/9798) from
behind the [ember-testing-checkbox-helpers](https://github.com/emberjs/ember.js/blob/860bb4be498466ac4c914adb1f139e5cd2fbc123/FEATURES.md#feature-flags) feature flag.

Matches Capybara's [#check](http://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Actions#check-instance_method) and [#uncheck](http://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Actions#uncheck-instance_method) helper methods.

Additionally introduces `assert.checked` and `assert.unchecked` QUnit
assertions.
