### PR TITLE
Fix inclusion matchers failure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Fix `assert.include` and `assert.notInclude` default failure message.
+
 0.0.3
 -----
 

--- a/addon/extend-qunit.js
+++ b/addon/extend-qunit.js
@@ -30,7 +30,7 @@ assert.include = function(actual, expected, message) {
   const actualString = normalizeString(actual);
 
   if (!message) {
-    message = `Expected '${actual}' to include '${expected}'`;
+    message = `Expected '${actualString}' to include '${expected}'`;
   }
 
   this.ok(actualString.indexOf(expected) !== -1, message);
@@ -40,7 +40,7 @@ assert.notInclude = function(actual, expected, message) {
   const actualString = normalizeString(actual);
 
   if (!message) {
-    message = `Expected '${actual}' not to include '${expected}'.`;
+    message = `Expected '${actualString}' not to include '${expected}'.`;
   }
 
   this.ok(actualString.indexOf(expected) === -1, message);


### PR DESCRIPTION
`assert.include` and `assert.notInclude` default failure messages didn't
print the text for DOM nodes.

They're now fail with the normalized text as part of the message.
