### PR TITLE
Append Custom Failure Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 master
 ------
 
+* When an QUnit matcher fails, the message includes both the default
+  failure message and any user-provided failure message. [#11]
+
+[#11]: https://github.com/thoughtbot/ralphs-little-helpers/pull/11
+
 0.0.4
 -----
 

--- a/addon/extend-qunit.js
+++ b/addon/extend-qunit.js
@@ -3,6 +3,14 @@ import QUnit from 'qunit';
 
 const { assert } = QUnit;
 
+function failureMessage(base, custom) {
+  if (custom) {
+    return `${base}: ${custom}`;
+  } else {
+    return base;
+  }
+}
+
 function normalizeString(actual) {
   if (!actual) {
     actual = '';
@@ -15,7 +23,7 @@ function normalizeString(actual) {
   }
 }
 
-assert.textEqual = function(actual, expected, message) {
+assert.textEqual = function(actual, expected, custom) {
   const actualString = normalizeString(actual);
 
   const trimActual = actualString
@@ -23,58 +31,58 @@ assert.textEqual = function(actual, expected, message) {
     .replace(/^\s+|\s+$/g, '')
     .replace('\n', ' ');
 
-  this.equal(trimActual, expected, message);
+  this.equal(trimActual, expected, custom);
 };
 
-assert.include = function(actual, expected, message) {
+assert.include = function(actual, expected, custom) {
   const actualString = normalizeString(actual);
+  const message = `Expected '${actualString}' to include '${expected}'`;
 
-  if (!message) {
-    message = `Expected '${actualString}' to include '${expected}'`;
-  }
-
-  this.ok(actualString.indexOf(expected) !== -1, message);
+  this.ok(
+    actualString.indexOf(expected) !== -1,
+    failureMessage(message, custom)
+  );
 };
 
-assert.notInclude = function(actual, expected, message) {
+assert.notInclude = function(actual, expected, custom) {
   const actualString = normalizeString(actual);
+  const message = `Expected '${actualString}' not to include '${expected}'`;
 
-  if (!message) {
-    message = `Expected '${actualString}' not to include '${expected}'.`;
-  }
-
-  this.ok(actualString.indexOf(expected) === -1, message);
+  this.ok(
+    actualString.indexOf(expected) === -1,
+    failureMessage(message, custom)
+  );
 };
 
-assert.hasClass = function(selectorOrNode, expected, message) {
+assert.hasClass = function(selectorOrNode, expected, custom) {
   const node = Ember.$(selectorOrNode);
   const classes = node.prop('class');
+  const message = `expected node to include "${expected}" class in "${classes}"`;
 
-  if (!message) {
-    message = `expected node to include "${expected}" class in "${classes}"`;
-  }
-
-  this.ok(node.hasClass(expected.toString()), message);
+  this.ok(
+    node.hasClass(expected.toString()),
+    failureMessage(message, custom)
+  );
 };
 
-assert.checked = function(selectorOrNode, message) {
+assert.checked = function(selectorOrNode, custom) {
   const node = Ember.$(selectorOrNode);
   const checked = node.is(':checked');
+  const message = `expected node (${selectorOrNode.toString()}) to be checked`;
 
-  if (!message) {
-    message = `expected node (${selectorOrNode.toString()}) to be checked`;
-  }
-
-  this.ok(checked, message);
+  this.ok(
+    checked,
+    failureMessage(message, custom)
+  );
 };
 
-assert.unchecked = function(selectorOrNode, message) {
+assert.unchecked = function(selectorOrNode, custom) {
   const node = Ember.$(selectorOrNode);
   const unchecked = !node.is(':checked');
+  const message = `expected node (${selectorOrNode.toString()}) to be unchecked`;
 
-  if (!message) {
-    message = `expected node (${selectorOrNode.toString()}) to be unchecked`;
-  }
-
-  this.ok(unchecked, message);
+  this.ok(
+    unchecked,
+    failureMessage(message, custom)
+  );
 };


### PR DESCRIPTION
When an assertion fails, the message should include both the default
failure message, as well as any user-provided failure message.
